### PR TITLE
Select appropriate cubemap shadow sizes

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -3728,7 +3728,7 @@ void RasterizerSceneGLES2::render_shadow(RID p_light, RID p_shadow_atlas, int p_
 
 				// find an appropriate cubemap to render to
 				for (int i = shadow_cubemaps.size() - 1; i >= 0; i--) {
-					if (shadow_cubemaps[i].size > shadow_size * 2) {
+					if (shadow_cubemaps[i].size > shadow_size) {
 						break;
 					}
 
@@ -4006,7 +4006,7 @@ void RasterizerSceneGLES2::initialize() {
 
 	// cubemaps for shadows
 	if (storage->config.support_shadow_cubemaps) { //not going to be used
-		int max_shadow_cubemap_sampler_size = CLAMP(int(next_power_of_2(GLOBAL_GET("rendering/quality/shadow_atlas/size")) >> 3), 256, storage->config.max_cubemap_texture_size);
+		int max_shadow_cubemap_sampler_size = CLAMP(int(next_power_of_2(GLOBAL_GET("rendering/quality/shadow_atlas/size")) >> 1), 256, storage->config.max_cubemap_texture_size);
 
 		int cube_size = max_shadow_cubemap_sampler_size;
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4811,7 +4811,7 @@ void RasterizerSceneGLES3::render_shadow(RID p_light, RID p_shadow_atlas, int p_
 
 				for (int i = shadow_cubemaps.size() - 1; i >= 0; i--) {
 					//find appropriate cubemap to render to
-					if (shadow_cubemaps[i].size > shadow_size * 2)
+					if (shadow_cubemaps[i].size > shadow_size)
 						break;
 
 					cubemap_index = i;
@@ -5105,7 +5105,7 @@ void RasterizerSceneGLES3::initialize() {
 
 	shadow_atlas_realloc_tolerance_msec = 500;
 
-	int max_shadow_cubemap_sampler_size = CLAMP(int(next_power_of_2(GLOBAL_GET("rendering/quality/shadow_atlas/size")) >> 3), 256, storage->config.max_cubemap_texture_size);
+	int max_shadow_cubemap_sampler_size = CLAMP(int(next_power_of_2(GLOBAL_GET("rendering/quality/shadow_atlas/size")) >> 1), 256, storage->config.max_cubemap_texture_size);
 
 	int cube_size = max_shadow_cubemap_sampler_size;
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2403,10 +2403,10 @@ VisualServer::VisualServer() {
 	GLOBAL_DEF("rendering/limits/time/time_rollover_secs", 3600);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/limits/time/time_rollover_secs", PropertyInfo(Variant::REAL, "rendering/limits/time/time_rollover_secs", PROPERTY_HINT_RANGE, "0,10000,1,or_greater"));
 
-	GLOBAL_DEF("rendering/quality/directional_shadow/size", 4096);
+	GLOBAL_DEF_RST("rendering/quality/directional_shadow/size", 4096);
 	GLOBAL_DEF("rendering/quality/directional_shadow/size.mobile", 2048);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/directional_shadow/size", PropertyInfo(Variant::INT, "rendering/quality/directional_shadow/size", PROPERTY_HINT_RANGE, "256,16384"));
-	GLOBAL_DEF("rendering/quality/shadow_atlas/size", 4096);
+	GLOBAL_DEF_RST("rendering/quality/shadow_atlas/size", 4096);
 	GLOBAL_DEF("rendering/quality/shadow_atlas/size.mobile", 2048);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/shadow_atlas/size", PropertyInfo(Variant::INT, "rendering/quality/shadow_atlas/size", PROPERTY_HINT_RANGE, "256,16384"));
 	GLOBAL_DEF("rendering/quality/shadow_atlas/quadrant_0_subdiv", 1);


### PR DESCRIPTION
Forgive me, I got a little carried away while testing your PR :P

This PR does 3 things to your PR:

1. We select a smaller cubemap, instead of selecting the largest cubemap smaller than 2 times the size of the quadrant (typically quadrant size) we select the largest cubemap smaller than the quadrant. This makes intuitive sense because you take the 6 faces of the cubemap and spread it over the quadrant. So it makes no sense for each face of the cubemap to be larger than the quadrant. From empirical testing, you start to notice artifacts when selecting the next smallest level cubemap as well. So getting the largest cubemap smaller than the quadrant seems to be the sweet spot. 
2. Asks users to restart when changing atlas shadow size for directional and for omnilight
3. Allocates a much larger cubemap array. This is necessary to make 1) work properly. 

The result of this PR combined with yours is substantially better shadow quality for little additional cost. 

In testing with 32 moving lights all with shadows on, I found a slight performance decrease with this PR. However, the quality is so much better that users will be able to get away with smaller atlas sizes. So the benefits are worth it. 

_Before 4096 atlas size; PCF13_
![Screenshot (132)](https://user-images.githubusercontent.com/16521339/111949922-c8026c80-8a9e-11eb-953d-6f386d68acc2.png)
![Screenshot (133)](https://user-images.githubusercontent.com/16521339/111949935-ca64c680-8a9e-11eb-978e-c298ed91ae37.png)


_After 4096 atlas size; PCF13_
![Screenshot (131)](https://user-images.githubusercontent.com/16521339/111949943-ce90e400-8a9e-11eb-9b3b-b55cc933eb06.png)
![Screenshot (135)](https://user-images.githubusercontent.com/16521339/111949945-cfc21100-8a9e-11eb-890d-621bf38f0be8.png)

